### PR TITLE
Fix up README.md with reference to correct name of `JsonView` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $container = $app->getContainer();
 
 // Register JSON View helper
 $container['view'] = function ($c) {
-    return new \Slim\Views\JSON();
+    return new \Slim\Views\JsonView();
 };
 
 // Successful response


### PR DESCRIPTION
This is small PR to update the README

I was wondering why this wasn't working for me and I realised the sample code in the README references the class `\Slim\Views\JSON` but the actual name of the class is `\Slim\Views\JsonView`